### PR TITLE
Fix #19

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ var RewriteCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		lroot, err := filepath.EvalSymlinks(lroot)
+		lroot, err := filepath.EvalSymlinks(mroot)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -276,10 +276,15 @@ var RewriteCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		root, err := gx.GetPackageRoot()
+		mroot, err := gx.GetPackageRoot()
 		if err != nil {
 			return err
 		}
+		lroot, err := filepath.EvalSymlinks(lroot)
+		if err != nil {
+			return err
+		}
+		root := lroot
 
 		if c.Bool("fix") {
 			return fixImports(root)


### PR DESCRIPTION
This pull request fixes #19 in a way consistent with [the current code](https://github.com/whyrusleeping/gx-go/blob/master/main.go#L76).

I think the issue was caused by the fact that the `gx.GetPackageRoot()` function uses `os.Getwd()` but doesn't evaluate symlinks.
The desired behaviour as illustrated by the top-level `cwd` variable is to evaluate symlinks after using `os.Getwd()`.

This pull request makes this behaviour consistent by evaluating symlinks in `gx.GetPackageRoot()`'s output.