### PR TITLE
Small documentation change: clarify dvcs-deps description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ COMMANDS:
      rewrite, rw  temporary hack to evade causality
      uw
      update       update a packages imports to a new path
-     dvcs-deps    display dvcs deps that arent tracked in gx
+     dvcs-deps    display all dvcs deps
      get          gx-ified `go get`
 
 GLOBAL OPTIONS:

--- a/main.go
+++ b/main.go
@@ -336,7 +336,7 @@ var RewriteCommand = cli.Command{
 
 var DvcsDepsCommand = cli.Command{
 	Name:  "dvcs-deps",
-	Usage: "display dvcs deps that arent tracked in gx",
+	Usage: "display all dvcs deps",
 	Action: func(c *cli.Context) error {
 		i, err := NewImporter(false, os.Getenv("GOPATH"), nil)
 		if err != nil {


### PR DESCRIPTION
When playing around with this today I noticed that the description made me think that only those dvcs deps NOT tracked by gx would be listed, but that (as far as I can tell) all dvcs deps are listed.