### PR TITLE
devcopy: check if symlink exists before making it

### DIFF
--- a/main.go
+++ b/main.go
@@ -815,8 +815,12 @@ func devCopySymlinking(root string, pkg *Package, done map[string]bool) error {
 			return err
 		}
 
-		if err := os.Symlink(frompath, topath); err != nil {
-			return err
+		if _, err := os.Stat(topath); err != nil && os.IsNotExist(err) {
+			if err := os.Symlink(frompath, topath); err != nil {
+				return err
+			}
+		} else {
+			VLog("Package already exists in vendor tree: ", topath)
 		}
 
 		if err := devCopySymlinking(root, &cpkg, done); err != nil {


### PR DESCRIPTION
This will prevent errors about the directory already existing in the vendor tree.

```
ERROR: Error: symlink /goworkspace/src/github.com/ipfs/go-ipfs/vendor/gx/ipfs/QmXPKMT5cT8ajqamSD1YaeEpfeaHvs9AU4MQzte4Bkr6V4/sys /goworkspace/src/github.com/ipfs/go-ipfs/vendor/golang.org/x/sys: file exists
```