### PR TITLE
speedup gx-go rw/uw

### DIFF
--- a/rewrite/rewrite.go
+++ b/rewrite/rewrite.go
@@ -112,8 +112,13 @@ func rewriteImportsInFile(fi string, rw func(string) string) error {
 	if err != nil {
 		return err
 	}
+	bw := bufio.NewWriter(w)
 
-	if err = cfg.Fprint(w, fset, file); err != nil {
+	if err = cfg.Fprint(bw, fset, file); err != nil {
+		return err
+	}
+
+	if err := bw.Flush(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
(10x)

Question: why did we use transitive dependencies when computing rewrites? IMO, we should definitely not be doing that. It's also slow.