### PR TITLE
Fix gx-go rewrite behaviour when argumts are provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ var rewriteUndoAlias = cli.Command{
 var RewriteCommand = cli.Command{
 	Name:      "rewrite",
 	Usage:     "temporary hack to evade causality",
-	ArgsUsage: "[optional package name]",
+	ArgsUsage: "[optional package name(s)]",
 	Aliases:   []string{"rw"},
 	Flags: []cli.Flag{
 		cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -283,6 +283,12 @@ var RewriteCommand = cli.Command{
 		}
 
 		if c.Bool("fix") {
+			if c.Args().Present() {
+				return fmt.Errorf("rewrite: --fix option does not take arguments")
+			}
+			if c.Bool("dry-run") {
+				return fmt.Errorf("rewrite: --fix option does not support --dry-run option")
+			}
 			return fixImports(root)
 		}
 


### PR DESCRIPTION
`gx-go rewrite` is now recursive, that is it doesn't require all the packages used as imports be listed in `package.json`.  However, `gx-go rewrite <arg> ...` is not.  This can create problems when trying rewrite a dep, used but not specified in `package.json`.

This fixed it by first creating the rewrite map then filtering map based on the arguments if specified.

This also means that it will not return an error if a package specified on the command line was not used as an import.  However, I actually see that as a plus.

I needed this when discovering some bugs when pushing through the go-cid changes.  I wanted to selectively rewrite all involved dependencies, but didn't want to pull in git versions of everything.  This initially failed because some of the `package.json` files do not directly specify all imports used.

This is a change in behavior, so if this will break things I can make it an option, but thought I didn't see a strong need to preserve the old behavior.

Also, the `--fix` option ignores both `--dry-run` and any arguments.  This should eventually be fixed but for now I just detected it and returned an error.